### PR TITLE
cmake: add missing librt dependency

### DIFF
--- a/ase/api/CMakeLists.txt
+++ b/ase/api/CMakeLists.txt
@@ -28,6 +28,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project("ase")
 find_package(Threads REQUIRED)
+find_package(RT REQUIRED)
 
 add_definitions(-DHAVE_CONFIG_H=1)
 set(API_DIR ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
libase.so is missing the dependency, so at runtime it will give an error about unknown symbol `shm_open`.