### PR TITLE
Add `-std=c99` to `CC_OPT`

### DIFF
--- a/ase/Makefile
+++ b/ase/Makefile
@@ -195,6 +195,7 @@ CC_OPT+= -g $(CC_INT_SIZE) -fPIC -D SIM_SIDE=1 -I $(ASE_SRCDIR)/sw/
 CC_OPT+= -D SIMULATOR=$(SIMULATOR) -D $(ASE_PLATFORM)
 CC_OPT+= -Wall -Wformat -Wformat-security
 CC_OPT+= -O2 -D_FORTIFY_SOURCE=2
+CC_OPT+= -std=c99
 ifeq ($(GCC_VERSION_GT_49),1)
   CC_OPT+= -fstack-protector-strong
   CC_OPT+= -z noexecstack -z relro -z now


### PR DESCRIPTION
This patch fixes the following error for me:

```
cd work ; gcc  -g -m32 -fPIC -D SIM_SIDE=1 -I /sim/sw/ -D SIMULATOR=QUESTA -D FPGA_PLATFORM_DISCRETE -Wall -Wformat -Wformat-security -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all -I /opt/intelFPGA_pro/quartus_19.2.0b57/modelsim_ase/include/ -c /sim/sw/ase_ops.c /sim/sw/ase_strings.c /sim/sw/ipc_mgmt_ops.c /sim/sw/ase_shbuf.c /sim/sw/protocol_backend.c /sim/sw/pcie_tlp_debug.c /sim/sw/pcie_tlp_stream.c /sim/sw/tstamp_ops.c /sim/sw/mqueue_ops.c /sim/sw/error_report.c /sim/sw/linked_list_ops.c /sim/sw/randomness_control.c  || exit 1
/sim/sw/pcie_tlp_debug.c: In function ‘fprintf_tlp_payload’:
/sim/sw/pcie_tlp_debug.c:108:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = n_dwords - 1; i >= 0; i -= 1)
     ^
/sim/sw/pcie_tlp_debug.c:108:5: note: use option -std=c99 or -std=gnu99 to compile your code
/sim/sw/pcie_tlp_stream.c: In function ‘pcie_tlp_a2h_cpld’:
/sim/sw/pcie_tlp_stream.c:499:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < payload_dws; i += 1)
     ^
/sim/sw/pcie_tlp_stream.c:499:5: note: use option -std=c99 or -std=gnu99 to compile your code
/sim/sw/pcie_tlp_stream.c: In function ‘pcie_tlp_a2h_mwr’:
/sim/sw/pcie_tlp_stream.c:615:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < payload_dws; i += 1)
     ^
/sim/sw/pcie_tlp_stream.c: In function ‘pcie_tlp_h2a_mem’:
/sim/sw/pcie_tlp_stream.c:1173:13: error: ‘for’ loop initial declarations are only allowed in C99 mode
             for (int i = 0; i < req_dw; i += 1)
             ^
/sim/sw/pcie_tlp_stream.c: In function ‘pcie_tlp_h2a_cpld’:
/sim/sw/pcie_tlp_stream.c:1280:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < rsp_dw; i += 1)
         ^
/sim/sw/pcie_tlp_stream.c: In function ‘pcie_param_init’:
/sim/sw/pcie_tlp_stream.c:1361:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < read_rsp_n_entries; i += 1)
         ^
/sim/sw/pcie_tlp_stream.c:1371:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < read_rsp_n_entries; i += 1)
     ^
make: *** [sw_build] Error 1
```

The relevant change was introduced in: https://github.com/OPAE/opae-sim/commit/22a4a2d159e40c082499255aca7d980e855e4d48