### PR TITLE
ase: remove reference to unused structures

### DIFF
--- a/ase/api/src/plugin.c
+++ b/ase/api/src/plugin.c
@@ -165,11 +165,6 @@ int __FPGA_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 	adapter->finalize =
 		dlsym(adapter->plugin.dl_handle, "ase_plugin_finalize");
 
-	adapter->supports_device = dlsym(adapter->plugin.dl_handle,
-					 "ase_plugin_supports_device");
-	adapter->supports_host =
-		dlsym(adapter->plugin.dl_handle, "ase_plugin_supports_host");
-
 	adapter->fpgaGetNumMetrics =
 		dlsym(adapter->plugin.dl_handle, "ase_fpgaGetNumMetrics");
 


### PR DESCRIPTION
Update ase plugin to latest plugin API (by removing reference to two fields removed from the opae_api_adapter_table structure.