### PR TITLE
api: adopt OPAE common token header

### DIFF
--- a/ase/api/src/common.c
+++ b/ase/api/src/common.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -238,7 +238,7 @@ struct _fpga_token *token_get_parent(struct _fpga_token *_t)
 		printf(" Token is NULL");
 	}
 
-	if (0 == memcmp(_t->accelerator_id, FPGA_FME_GUID, sizeof(fpga_guid))) {
+	if (0 == memcmp(_t->hdr.guid, FPGA_FME_GUID, sizeof(fpga_guid))) {
 		return NULL;
 	} else {
 		return &aseToken[0];

--- a/ase/api/src/open.c
+++ b/ase/api/src/open.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2014-2018, Intel Corporation
+// Copyright(c) 2014-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -69,7 +69,7 @@ fpga_result __FPGA_API__ ase_fpgaOpen(fpga_token token, fpga_handle *handle, int
 
 	_token = (struct _fpga_token *)token;
 
-	if (_token->magic != ASE_TOKEN_MAGIC) {
+	if (_token->hdr.magic != ASE_TOKEN_MAGIC) {
 		FPGA_MSG("Invalid token");
 		return FPGA_INVALID_PARAM;
 	}

--- a/ase/api/src/token.h
+++ b/ase/api/src/token.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2017, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -25,6 +25,34 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 static struct _fpga_token aseToken[2] = {
-	{ .magic = 0x46504741544f4b40, .accelerator_id = {0}, .ase_objtype = FPGA_DEVICE },
-	{ .magic = 0x46504741544f4b40, .accelerator_id = {0}, .ase_objtype = FPGA_ACCELERATOR}
+	{
+		{
+			.magic = ASE_TOKEN_MAGIC,
+			.vendor_id = 0x8086,
+			.device_id = ASE_ID,
+			.segment = 0,
+			.bus = ASE_BUS,
+			.device = ASE_DEVICE,
+			.function = ASE_FUNCTION,
+			.interface = FPGA_IFC_SIM,
+			.objtype = FPGA_DEVICE,
+			.object_id = ASE_OBJID,
+			.guid = { 0, }
+		},
+	},
+	{
+		{
+			.magic = ASE_TOKEN_MAGIC,
+			.vendor_id = 0x8086,
+			.device_id = ASE_ID,
+			.segment = 0,
+			.bus = ASE_BUS,
+			.device = ASE_DEVICE,
+			.function = ASE_FUNCTION,
+			.interface = FPGA_IFC_SIM,
+			.objtype = FPGA_ACCELERATOR,
+			.object_id = ASE_OBJID,
+			.guid = { 0, }
+		}
+	}
 };

--- a/ase/api/src/types_int.h
+++ b/ase/api/src/types_int.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2017, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -57,6 +57,7 @@
 #define ASE_TOKEN_MAGIC    0x46504741544f4b40
 #define ASE_OBJID          0x0000000000a53a53
 #define ASE_NUM_SLOTS      1
+#define ASE_ID             0x0A5E
 #define ASE_BUS            1
 #define ASE_DEVICE         1
 #define ASE_FUNCTION       0
@@ -67,9 +68,7 @@
 
 /** System-wide unique FPGA resource identifier */
 struct _fpga_token {
-	uint64_t magic;
-	fpga_guid accelerator_id;
-	fpga_objtype ase_objtype;
+	fpga_token_header hdr;
 };
 
 /** Process-wide unique FPGA handle */


### PR DESCRIPTION
See opae-libs/include/opae/types.h:fpga_token_header.
Implementing the common token header format allows filtering/
properties to discern the parent/child token relationship
across plugin boundaries.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>