### PR TITLE
sw: resolve github issue 2289

### DIFF
--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2014-2018, Intel Corporation
+// Copyright(c) 2014-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -570,7 +570,7 @@ struct ipc_t {
 	char path[ASE_FILEPATH_LEN];
 	int perm_flag;
 };
-struct ipc_t mq_array[ASE_MQ_INSTANCES];
+extern struct ipc_t mq_array[ASE_MQ_INSTANCES];
 
 
 /* ********************************************************************
@@ -625,9 +625,10 @@ int unregister_event(int event_handle);
 // #define ASE_BUFFER_VIEW
 
 // Backtrace data
-int bt_j, bt_nptrs;
-void *bt_buffer[4096];
-char **bt_strings;
+extern int bt_j;
+extern int bt_nptrs;
+extern void *bt_buffer[4096];
+extern char **bt_strings;
 
 
 /* *********************************************************************

--- a/ase/sw/error_report.c
+++ b/ase/sw/error_report.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2014-2018, Intel Corporation
+// Copyright(c) 2014-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -92,6 +92,11 @@ void ase_error_report(const char *err_func, int err_num, int err_code)
 	END_RED_FONTCOLOR;
 }
 
+
+int bt_j = 0;
+int bt_nptrs = 0;
+void *bt_buffer[4096] = { 0, };
+char **bt_strings = NULL;
 
 /*
  * Wrapper for backtrace handler


### PR DESCRIPTION
Place global variable definitions in the .c file and extern
statement in the .h to avoid multiple variable def's.

https://github.com/OPAE/opae-sdk/issues/2289

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>