### PR TITLE
api: fix the include search order

### DIFF
--- a/ase/api/CMakeLists.txt
+++ b/ase/api/CMakeLists.txt
@@ -66,10 +66,10 @@ target_link_libraries(ase
 # compiling the library, and will be added to consumers' build
 # paths. Keep current directory private.
 target_include_directories(ase PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../include>
   $<BUILD_INTERFACE:${OPAE_INCLUDE_PATH}>
   $<INSTALL_INTERFACE:include>
   PRIVATE src
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../include>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../sw>
   PRIVATE ${OPAE_LIB_SOURCE}/libopae-c)
 


### PR DESCRIPTION
This was breaking on RHEL8. It was finding the OPAE SDK's config.h
rather than ASE's config.h. Move the ASE search path to the top to
fix.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>