### PR TITLE
prop: implement subsystem_vendor, subsystem_device

### DIFF
--- a/ase/api/src/enum.c
+++ b/ase/api/src/enum.c
@@ -370,6 +370,12 @@ ase_fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 	_iprop.device_id = ASE_ID;
 	SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_DEVICEID);
 
+	_iprop.subsystem_vendor_id = 0x8086;
+	SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_SUB_VENDORID);
+
+	_iprop.subsystem_device_id = ASE_ID;
+	SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_SUB_DEVICEID);
+
 	_iprop.bus = ASE_BUS;
 	SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_BUS);
 

--- a/ase/api/src/token.h
+++ b/ase/api/src/token.h
@@ -37,7 +37,9 @@ static struct _fpga_token aseToken[2] = {
 			.interface = FPGA_IFC_SIM,
 			.objtype = FPGA_DEVICE,
 			.object_id = ASE_OBJID,
-			.guid = { 0, }
+			.guid = { 0, },
+			.subsystem_vendor_id = 0x8086,
+			.subsystem_device_id = ASE_ID
 		},
 	},
 	{
@@ -52,7 +54,9 @@ static struct _fpga_token aseToken[2] = {
 			.interface = FPGA_IFC_SIM,
 			.objtype = FPGA_ACCELERATOR,
 			.object_id = ASE_OBJID,
-			.guid = { 0, }
+			.guid = { 0, },
+			.subsystem_vendor_id = 0x8086,
+			.subsystem_device_id = ASE_ID
 		}
 	}
 };


### PR DESCRIPTION
Implement 2 new properties - subsystem_vendor and subsystem_device.
These two uniquely identify a device, even though vendor/device ID
may not change from one generation to the next.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>