### PR TITLE
build: update how ase finds opae

### DIFF
--- a/ase/CMakeLists.txt
+++ b/ase/CMakeLists.txt
@@ -30,6 +30,8 @@ project(ase)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(ase_libs)
 include(opae_devpkgs_cmake_install)
+find_package(opae REQUIRED)
+include(OPAEGit)
 
 set(ASE_VERSION_MAJOR    1 CACHE STRING "ASE major version" FORCE)
 set(ASE_VERSION_MINOR    4 CACHE STRING "ASE minor version" FORCE)

--- a/ase/api/src/common_int.h
+++ b/ase/api/src/common_int.h
@@ -39,10 +39,9 @@
 #include <sys/mman.h>  /* mmap & munmap */
 #include <sys/time.h>  /* struct timeval */
 
-#include "opae/utils.h"
+#include <opae/plugin.h>
 #include "types_int.h"
 #include "wsid_list_int.h"
-#include "props.h"
 
 /* Macro for defining symbol visibility */
 #define __FPGA_API__ __attribute__((visibility("default")))

--- a/ase/api/src/enum.c
+++ b/ase/api/src/enum.c
@@ -31,6 +31,7 @@
 #include <opae/enum.h>
 #include <opae/properties.h>
 #include <opae/utils.h>
+#include <opae/plugin.h>
 #include "common_int.h"
 #include "token.h"
 #include <stdlib.h>
@@ -44,7 +45,6 @@ uint32_t session_exist_status = NOT_ESTABLISHED;
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include "props.h"
 #define ASE_FME_ID 0x3345678UL
 #define BBSID 0x63000023b637277UL
 #define FPGA_NUM_SLOTS 1

--- a/ase/api/src/plugin.c
+++ b/ase/api/src/plugin.c
@@ -30,7 +30,6 @@
 
 #include <dlfcn.h>
 #include "common_int.h"
-#include "adapter.h"
 
 int __FPGA_API__ ase_plugin_initialize(void)
 {


### PR DESCRIPTION
The following changes were recently made to what OPAE installs:
* install plugin related headers in include/opae/plugin
  * opae_int.h
  * adapter.h
  * props.h
* install plugin.h in include /opae that includes the aforementioned
  headers
* install cmake config files in /usr/lib/opae-<version>

With these changes, ASE's plugin implementation needs to be changed to
reflect the new includes as well as to use cmake find_package to find
OPAE. If OPAE is installed in a non-standard path then one can set
CMAKE_PREFIX_PATH environment to point to that path prior to running
cmake config in this project.

Example:
OPAE is installed using prefix /some/arbitrary/path.
Then, to configure cmake for this project, run:
``` bash
git clone https://github.com/OPAE/opae-sim.git
cd opae-sim
mkdir build
CMAKE_PREFIX_PATH=/some/arbitrary/path cmake ..
make
```

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>